### PR TITLE
Add legacy project metadata API endpoint

### DIFF
--- a/src/main/java/io/spring/projectapi/web/release/LegacyReleasesController.java
+++ b/src/main/java/io/spring/projectapi/web/release/LegacyReleasesController.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.projectapi.web.release;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.spring.projectapi.contentful.ContentfulService;
+import io.spring.projectapi.contentful.ProjectDocumentation;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Legacy API for Initializr clients.
+ *
+ * @author Brian Clozel
+ */
+@RestController
+public class LegacyReleasesController {
+
+	private final ContentfulService contentfulService;
+
+	public LegacyReleasesController(ContentfulService contentfulService) {
+		this.contentfulService = contentfulService;
+	}
+
+	@GetMapping(value = "/project_metadata/spring-boot", produces = MediaType.APPLICATION_JSON_VALUE)
+	public SpringBootMetadata springBootMetadata() {
+		List<ProjectDocumentation> documentations = this.contentfulService.getProjectDocumentations("spring-boot");
+		return new SpringBootMetadata(documentations);
+	}
+
+	public static final class SpringBootMetadata {
+
+		private final List<SpringBootRelease> projectReleases;
+
+		SpringBootMetadata(List<ProjectDocumentation> documentations) {
+			this.projectReleases = documentations.stream().map(SpringBootRelease::fromDocumentation)
+					.collect(Collectors.toList());
+		}
+
+		public String getId() {
+			return "spring-boot";
+		}
+
+		public String getName() {
+			return "Spring Boot";
+		}
+
+		public List<SpringBootRelease> getProjectReleases() {
+			return this.projectReleases;
+		}
+
+	}
+
+	public static final class SpringBootRelease {
+
+		private final String version;
+
+		private final String versionDisplayName;
+
+		private final boolean current;
+
+		private final String releaseStatus;
+
+		private final boolean snapshot;
+
+		private SpringBootRelease(String version, String versionDisplayName, boolean current, String releaseStatus,
+				boolean snapshot) {
+			this.version = version;
+			this.versionDisplayName = versionDisplayName;
+			this.current = current;
+			this.releaseStatus = releaseStatus;
+			this.snapshot = snapshot;
+		}
+
+		public String getVersion() {
+			return this.version;
+		}
+
+		public String getVersionDisplayName() {
+			return this.versionDisplayName;
+		}
+
+		public boolean isCurrent() {
+			return this.current;
+		}
+
+		public String getReleaseStatus() {
+			return this.releaseStatus;
+		}
+
+		public boolean isSnapshot() {
+			return this.snapshot;
+		}
+
+		static SpringBootRelease fromDocumentation(ProjectDocumentation projectDocumentation) {
+			return new SpringBootRelease(projectDocumentation.getVersion(), projectDocumentation.getVersion(),
+					projectDocumentation.isCurrent(), projectDocumentation.getStatus().name(),
+					ProjectDocumentation.Status.SNAPSHOT.equals(projectDocumentation.getStatus()));
+		}
+
+	}
+
+}

--- a/src/test/java/io/spring/projectapi/web/release/LegacyReleasesControllerTests.java
+++ b/src/test/java/io/spring/projectapi/web/release/LegacyReleasesControllerTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.projectapi.web.release;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.spring.projectapi.contentful.ContentfulService;
+import io.spring.projectapi.contentful.ProjectDocumentation;
+import io.spring.projectapi.contentful.ProjectDocumentation.Status;
+import io.spring.projectapi.security.SecurityConfiguration;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Tests for {@link LegacyReleasesController}.
+ *
+ * @author Madhura Bhave
+ * @author Phillip Webb
+ * @author Brian Clozel
+ */
+@WebMvcTest(LegacyReleasesController.class)
+@AutoConfigureWebClient
+@Import(SecurityConfiguration.class)
+class LegacyReleasesControllerTests {
+
+	@Autowired
+	private MockMvc mvc;
+
+	@MockBean
+	private ContentfulService contentfulService;
+
+	@Test
+	void legacyReleasesReturnsReleases() throws Exception {
+		given(this.contentfulService.getProjectDocumentations("spring-boot")).willReturn(getProjectDocumentations());
+		this.mvc.perform(get("/project_metadata/spring-boot").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.id").value("spring-boot"))
+				.andExpect(jsonPath("$.name").value("Spring Boot"))
+				.andExpect(jsonPath("$.projectReleases.length()").value("2"))
+				.andExpect(jsonPath("$.projectReleases[0].version").value("2.3.0"))
+				.andExpect(jsonPath("$.projectReleases[0].versionDisplayName").value("2.3.0"))
+				.andExpect(jsonPath("$.projectReleases[0].current").value(true))
+				.andExpect(jsonPath("$.projectReleases[0].releaseStatus").value("GENERAL_AVAILABILITY"))
+				.andExpect(jsonPath("$.projectReleases[0].snapshot").value(false))
+				.andExpect(jsonPath("$.projectReleases[1].version").value("2.3.1-SNAPSHOT"))
+				.andExpect(jsonPath("$.projectReleases[1].versionDisplayName").value("2.3.1-SNAPSHOT"))
+				.andExpect(jsonPath("$.projectReleases[1].current").value(false))
+				.andExpect(jsonPath("$.projectReleases[1].releaseStatus").value("SNAPSHOT"))
+				.andExpect(jsonPath("$.projectReleases[1].snapshot").value(true));
+	}
+
+	private List<ProjectDocumentation> getProjectDocumentations() {
+		List<ProjectDocumentation> result = new ArrayList<>();
+		String docsRoot;
+		docsRoot = "https://docs.spring.io/spring-boot/docs/2.3.0/";
+		result.add(new ProjectDocumentation("2.3.0", docsRoot + "api/", docsRoot + "reference/html/",
+				Status.GENERAL_AVAILABILITY, null, true));
+		docsRoot = "https://docs.spring.io/spring-boot/docs/2.3.1-SNAPSHOT/";
+		result.add(new ProjectDocumentation("2.3.1-SNAPSHOT", docsRoot + "api/", docsRoot + "reference/html/",
+				Status.SNAPSHOT, null, false));
+		return result;
+	}
+
+}


### PR DESCRIPTION
This commit adds a single "/project_metadata/spring-boot" endpoint that exposes the list of Spring Boot releases with a legacy format that is expected by Spring Initializr clients that are not yet up-to-date with the latest version of the Initializr library.